### PR TITLE
sq1-eduardo/s04-delecao-usuario

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2,11 +2,12 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Services\User\DeleteOneUserService;
 use App\Http\Services\User\GetAllUsersService;
+
 use App\Traits\HttpResponses;
 
 use Illuminate\Http\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 class UserController extends Controller
 {
@@ -19,5 +20,11 @@ class UserController extends Controller
         $users = $getAllUsersService->handle($search);
 
         return $users;
+    }
+
+    public function destroy($id, DeleteOneUserService $deleteOneUserService)
+    {
+
+        return $deleteOneUserService->handle($id);
     }
 }

--- a/app/Http/Repositories/UserRepository.php
+++ b/app/Http/Repositories/UserRepository.php
@@ -20,4 +20,20 @@ class UserRepository implements UserRepositoryInterface
             ->orderBy('id')
             ->get();
     }
+
+    public function find($id)
+    {
+        return User::find($id);
+    }
+
+    public function deactivateUser($user)
+    {
+        $user->is_active = false;
+        $user->save();
+    }
+
+    public function delete($user)
+    {
+        $user->delete();
+    }
 }

--- a/app/Http/Services/User/DeleteOneUserService.php
+++ b/app/Http/Services/User/DeleteOneUserService.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Services\User;
+
+use App\Http\Repositories\UserRepository;
+use App\Traits\HttpResponses;
+
+use Illuminate\Http\Response;
+
+class DeleteOneUserService
+{
+    use HttpResponses;
+
+    private $userRepository;
+
+    public function __construct(UserRepository $userRepository)
+    {
+        $this->userRepository = $userRepository;
+    }
+
+    public function handle($id)
+    {
+
+        $user = $this->userRepository->find($id);
+
+        if (!$user) {
+            return $this->error('O usuário não está cadastrado no banco de dados.', Response::HTTP_NOT_FOUND);
+        }
+
+        $this->userRepository->deactivateUser($user);
+        $this->userRepository->delete($user);
+
+        return $this->response('', Response::HTTP_NO_CONTENT);
+    }
+}

--- a/app/Interfaces/UserRepositoryInterface.php
+++ b/app/Interfaces/UserRepositoryInterface.php
@@ -4,4 +4,8 @@ namespace App\Interfaces;
 
 interface UserRepositoryInterface {
     public function getAll($search);
+
+    public function find($id);
+    public function deactivateUser($user);
+    public function delete($user);
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,10 +7,12 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class User extends Authenticatable
 {
     use HasApiTokens, HasFactory, Notifiable;
+    use SoftDeletes;
 
     /**
      * The attributes that are mass assignable.

--- a/database/migrations/2024_03_18_231837_add_sof_delete_to_users_table.php
+++ b/database/migrations/2024_03_18_231837_add_sof_delete_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::get('users', [UserController::class, 'index'])->middleware(['ability:get-users']);
+    Route::delete('users/{id}', [UserController::class, 'destroy'])->middleware(['ability:delete-users']);
     Route::get('students', [StudentController::class, 'index'])->middleware(['ability:get-students']);
     Route::get('workouts', [WorkoutController::class, 'index'])->middleware(['ability:get-workouts']);
 

--- a/tests/Unit/AdminDeleteTest.php
+++ b/tests/Unit/AdminDeleteTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class AdminDeleteTest extends TestCase
+{
+
+    public function test_admin_can_delete_users()
+    {
+        $user = User::factory()->create(['profile_id' => 1]);
+        $token = $user->createToken('@academia', ['delete-users'])->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)->delete('/api/users/2');
+
+        $response->assertStatus(204);
+    }
+
+    public function test_others_user_can_not_delete_users()
+    {
+        $user = User::factory()->create(['profile_id' => 2]);
+        $token = $user->createToken('@academia', [''])->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)->delete('/api/users/2');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_user_not_found_in_database()
+    {
+        $user = User::factory()->create(['profile_id' => 1]);
+        $token = $user->createToken('@academia', ['delete-users'])->plainTextToken;
+
+        $count = User::count();
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)->delete("/api/users/" . ($count + 1));
+
+        $response->assertStatus(404);
+
+        $response->assertJson([
+            "message" => "O usuário não está cadastrado no banco de dados.",
+            "status" => 404,
+            "errors" => [],
+            "data" => []
+        ]);
+    }
+}

--- a/tests/Unit/AdminDeleteTest.php
+++ b/tests/Unit/AdminDeleteTest.php
@@ -3,8 +3,6 @@
 namespace Tests\Feature;
 
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class AdminDeleteTest extends TestCase
@@ -15,7 +13,10 @@ class AdminDeleteTest extends TestCase
         $user = User::factory()->create(['profile_id' => 1]);
         $token = $user->createToken('@academia', ['delete-users'])->plainTextToken;
 
-        $response = $this->withHeader('Authorization', 'Bearer ' . $token)->delete('/api/users/2');
+        $otherUser = User::factory()->create(['profile_id' => 2]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->delete('/api/users/' . $otherUser->id);
 
         $response->assertStatus(204);
     }
@@ -25,7 +26,10 @@ class AdminDeleteTest extends TestCase
         $user = User::factory()->create(['profile_id' => 2]);
         $token = $user->createToken('@academia', [''])->plainTextToken;
 
-        $response = $this->withHeader('Authorization', 'Bearer ' . $token)->delete('/api/users/2');
+        $otherUser = User::factory()->create(['profile_id' => 2]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->delete('/api/users/' . $otherUser->id);
 
         $response->assertStatus(403);
     }
@@ -35,9 +39,10 @@ class AdminDeleteTest extends TestCase
         $user = User::factory()->create(['profile_id' => 1]);
         $token = $user->createToken('@academia', ['delete-users'])->plainTextToken;
 
-        $count = User::count();
+        $otherUser = User::factory()->create(['profile_id' => 2]);
 
-        $response = $this->withHeader('Authorization', 'Bearer ' . $token)->delete("/api/users/" . ($count + 1));
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->delete("/api/users/" . ($otherUser->id + 1));
 
         $response->assertStatus(404);
 


### PR DESCRIPTION
Este recurso habilita o admin a fazer uso da funcionalidade de exclusão suave (soft delete) para remover um usuário do sistema. Durante o processo de deleção, o sistema realiza uma modificação no estado da tabela, definindo o campo "is_active" como falso, indicando que o usuário foi desativado, mas ainda mantendo seus registros no banco de dados para futura consulta, se necessário.