### PR TITLE
Sq3-taisa/s02-cadastro-exercicio

### DIFF
--- a/app/Http/Controllers/ExerciseController.php
+++ b/app/Http/Controllers/ExerciseController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\ValidateExerciseRequest;
+use App\Http\Services\Exercise\CreateExerciseService;
+
+use App\Traits\HttpResponses;
+
+use Illuminate\Support\Facades\Auth;
+
+class ExerciseController extends Controller
+{
+    use HttpResponses;
+
+    public function store(
+        ValidateExerciseRequest $validateExerciseRequest,
+        CreateExerciseService $createExerciseService
+    ) {
+
+        $user_id = Auth::user()->id;
+
+        $description = $validateExerciseRequest->input('description');
+
+        return $createExerciseService->handle($user_id, $description);
+    }
+
+}

--- a/app/Http/Repositories/ExerciseRepository.php
+++ b/app/Http/Repositories/ExerciseRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Repositories;
+
+use App\Interfaces\ExerciseRepositoryInterface;
+use App\Models\Exercise;
+
+class ExerciseRepository implements ExerciseRepositoryInterface
+{
+
+    public function createExercise($userId, $description)
+    {
+        return Exercise::create([
+            'user_id' => $userId,
+            'description' => $description
+        ]);
+    }
+
+    public function findExerciseByUserIdAndDescription($userId, $description)
+    {
+        return Exercise::where('user_id', $userId)
+            ->where('description', $description)
+            ->first();
+    }
+}

--- a/app/Http/Requests/ValidateExerciseRequest.php
+++ b/app/Http/Requests/ValidateExerciseRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
+
+class ValidateExerciseRequest extends FormRequest
+{
+
+    protected $stopOnFirstFailure = true;
+
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+
+    public function authorize(): bool
+    {
+        return Auth::check();
+    }
+
+    /**
+     * Colocar a validação dessa classe
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'description' => 'string|required|max:255'
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'description.required' => 'O nome do exercício é obrigatório',
+            'description.string' => 'O nome do exercício deve ser uma string',
+            'description.max' => 'O exercício ultrapassa o limite de 255 caracteres'
+        ];
+    }
+}

--- a/app/Http/Services/Exercise/CreateExerciseService.php
+++ b/app/Http/Services/Exercise/CreateExerciseService.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Services\Exercise;
+
+use App\Http\Repositories\ExerciseRepository;
+use App\Traits\HttpResponses;
+
+use Illuminate\Http\Response;
+
+class CreateExerciseService
+{
+    use HttpResponses;
+
+    private $exerciseRepository;
+
+    public function __construct(ExerciseRepository $exerciseRepository)
+    {
+        $this->exerciseRepository = $exerciseRepository;
+    }
+
+    public function handle($userId, $description)
+    {
+
+        $existingExercise = $this->exerciseRepository->findExerciseByUserIdAndDescription($userId, $description);
+
+        if ($existingExercise) {
+            return response()->json(['message' => 'O exercício já existe para este usuário.'], Response::HTTP_CONFLICT);
+        }
+
+        return $this->exerciseRepository->createExercise($userId, $description);
+    }
+}

--- a/app/Interfaces/ExerciseRepositoryInterface.php
+++ b/app/Interfaces/ExerciseRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Interfaces;
+
+interface ExerciseRepositoryInterface {
+    public function createExercise($userId, $description);
+
+    public function findExerciseByUserIdAndDescription($userId, $description);
+}

--- a/app/Models/Exercise.php
+++ b/app/Models/Exercise.php
@@ -9,5 +9,15 @@ class Exercise extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['description'];
+    protected $fillable = ['description', 'user_id'];
+
+    protected $hidden = [
+        'user_id',
+        'updated_at',
+        'created_at',
+    ];
+
+    public function user_id() {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\AuthController;
+use App\Http\Controllers\ExerciseController;
 use App\Http\Controllers\StudentController;
 use App\Http\Controllers\WorkoutController;
 use Illuminate\Http\Request;
@@ -19,7 +20,7 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->group(function () {
     Route::get('students', [StudentController::class, 'index'])->middleware(['ability:get-students']);
     Route::get('workouts', [WorkoutController::class, 'index'])->middleware(['ability:get-workouts']);
-
+    Route::post('exercises', [ExerciseController::class, 'store'])->middleware(['ability:create-exercises']);
     Route::post('logout', [AuthController::class, 'logout']);
 });
 

--- a/tests/Unit/ExerciseInstructorStorageTest.php
+++ b/tests/Unit/ExerciseInstructorStorageTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Exercise;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class ExerciseInstructorStorageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_instructor_can_create_exercise()
+    {
+
+        $user = User::factory()->create(['profile_id' => 3]);
+        $token = $user->createToken('12345678', ['create-exercises'])->plainTextToken;
+
+        $exercise = [
+            'description' => 'Supino Canadense',
+        ];
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/exercises', $exercise);
+
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'description',
+                'id',
+            ]);
+
+        $this->assertDatabaseHas('exercises', $exercise);
+
+    }
+
+    public function test_other_users_can_not_create_exercise()
+    {
+
+        $this->withoutExceptionHandling();
+
+        $user = User::factory()->create(['profile_id' => 2]);
+        $token = $user->createToken('12345678', [''])->plainTextToken;
+
+        $exercise = [
+            'description' => 'Supino Canadense',
+        ];
+
+        //Capturar o erro de ausência da habilidade
+        $this->expectException(\Laravel\Sanctum\Exceptions\MissingAbilityException::class);
+
+        $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/exercises', $exercise);
+
+    }
+
+    public function test_exercise_already_exists_for_this_user()
+    {
+
+        $user = User::factory()->create(['profile_id' => 3]);
+        $token = $user->createToken('12345678', ['create-exercises'])->plainTextToken;
+
+        $exercise = [
+            'description' => "Supino Canadense",
+            'user_id' => $user->id
+        ];
+
+        Exercise::create($exercise);
+
+        // Tentar criar o mesmo exercício novamente
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/exercises', $exercise);
+
+        $response->assertStatus(409)
+            ->assertJson([
+                'message' => 'O exercício já existe para este usuário.',
+            ]);
+
+        $this->assertEquals(1, Exercise::count());
+
+    }
+}


### PR DESCRIPTION
Este pull request adiciona a funcionalidade de cadastro de exercícios. 
Os usuários logados no sistema com o perfil de instrutor podem adicionar novos exercícios associados às suas contas. Em caso de tentativa de registro de um exercício já existente para o usuário, o sistema irá retornar uma mensagem de erro informando sobre a duplicidade da informação.

Testes:
- Foram realizados testes unitários para garantir o funcionamento adequado do `ExerciseController` e do `CreateExerciseService`.
- Os testes abrangem cenários de sucesso e falha, incluindo a tentativa de criar um exercício já existente para o usuário, bem como a tentativa de cadastro de exercício por usuários sem permissão para realizar essa ação.
