### PR TITLE
Sq3-taisa/s04-delecao-exercicio

### DIFF
--- a/app/Http/Controllers/ExerciseController.php
+++ b/app/Http/Controllers/ExerciseController.php
@@ -9,6 +9,9 @@ use App\Traits\HttpResponses;
 
 use Illuminate\Support\Facades\Auth;
 
+use App\Http\Services\Exercise\DeleteOneExerciseService;
+
+
 class ExerciseController extends Controller
 {
     use HttpResponses;
@@ -25,4 +28,9 @@ class ExerciseController extends Controller
         return $createExerciseService->handle($user_id, $description);
     }
 
+    public function destroy($id, DeleteOneExerciseService $deleteOneExerciseService)
+    {
+
+        return $deleteOneExerciseService->handle($id);
+    }
 }

--- a/app/Http/Repositories/ExerciseRepository.php
+++ b/app/Http/Repositories/ExerciseRepository.php
@@ -4,9 +4,11 @@ namespace App\Http\Repositories;
 
 use App\Interfaces\ExerciseRepositoryInterface;
 use App\Models\Exercise;
+use App\Traits\HttpResponses;
 
 class ExerciseRepository implements ExerciseRepositoryInterface
 {
+    use HttpResponses;
 
     public function createExercise($userId, $description)
     {
@@ -21,5 +23,15 @@ class ExerciseRepository implements ExerciseRepositoryInterface
         return Exercise::where('user_id', $userId)
             ->where('description', $description)
             ->first();
+    }
+
+    public function findOne($id)
+    {
+        return Exercise::find($id);
+    }
+
+    public function deleteOne($exercise)
+    {
+        $exercise->delete();
     }
 }

--- a/app/Http/Services/Exercise/DeleteOneExerciseService.php
+++ b/app/Http/Services/Exercise/DeleteOneExerciseService.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Services\Exercise;
+
+use App\Http\Repositories\ExerciseRepository;
+use App\Traits\HttpResponses;
+
+use Illuminate\Http\Response;
+
+class DeleteOneExerciseService
+{
+    use HttpResponses;
+
+    private $exerciseRepository;
+
+    public function __construct(ExerciseRepository $exerciseRepository)
+    {
+        $this->exerciseRepository = $exerciseRepository;
+    }
+
+    public function handle($id)
+    {
+
+        $exercise = $this->exerciseRepository->findOne($id);
+
+        if (!$exercise) {
+            return $this->error('Exercício não encontrado no banco de dados.', Response::HTTP_NOT_FOUND);
+        }
+
+        $this->exerciseRepository->deleteOne($exercise);
+
+        return $this->response('', Response::HTTP_NO_CONTENT);
+    }
+}

--- a/app/Interfaces/ExerciseRepositoryInterface.php
+++ b/app/Interfaces/ExerciseRepositoryInterface.php
@@ -4,6 +4,7 @@ namespace App\Interfaces;
 
 interface ExerciseRepositoryInterface {
     public function createExercise($userId, $description);
-
     public function findExerciseByUserIdAndDescription($userId, $description);
+    public function findOne($id);
+    public function deleteOne($id);
 }

--- a/database/factories/ExerciseFactory.php
+++ b/database/factories/ExerciseFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Exercise>
+ */
+class ExerciseFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'description' => fake()->name(),
+            'user_id' => 3,
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,8 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('students', [StudentController::class, 'index'])->middleware(['ability:get-students']);
     Route::get('workouts', [WorkoutController::class, 'index'])->middleware(['ability:get-workouts']);
     Route::post('exercises', [ExerciseController::class, 'store'])->middleware(['ability:create-exercises']);
+    Route::delete('exercises/{id}', [ExerciseController::class, 'destroy'])->middleware(['ability:delete-exercises']);
+
     Route::post('logout', [AuthController::class, 'logout']);
 });
 

--- a/tests/Unit/ExerciseInstructorDeleteTest.php
+++ b/tests/Unit/ExerciseInstructorDeleteTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Exercise;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class ExerciseInstructorDeleteTest extends TestCase
+{
+
+    use RefreshDatabase;
+
+    public function test_instructor_can_delete_exercise()
+    {
+        $user = User::factory()->create(['profile_id' => 3]);
+        $token = $user->createToken('12345678', ['delete-exercises'])->plainTextToken;
+
+        $exercise = Exercise::factory()->create();
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->delete('/api/exercises/' . $exercise->id);
+
+        $response->assertStatus(204);
+    }
+
+    public function test_other_users_can_not_delete_exercise()
+    {
+        $this->withoutExceptionHandling();
+
+        $user = User::factory()->create(['profile_id' => 2]);
+        $token = $user->createToken('12345678', [''])->plainTextToken;
+
+        $exercise = Exercise::factory()->create();
+
+        //Capturar o erro de ausência da habilidade
+        $this->expectException(\Laravel\Sanctum\Exceptions\MissingAbilityException::class);
+
+        $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->delete('/api/exercises/' . $exercise->id);
+    }
+
+    public function test_exercise_not_found_in_database()
+    {
+        $user = User::factory()->create(['profile_id' => 3]);
+        $token = $user->createToken('12345678', ['delete-exercises'])->plainTextToken;
+
+        $exercise = Exercise::factory()->create();
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->delete('/api/exercises/' . $exercise->id + 1);
+
+        $response->assertStatus(404)->assertJson([
+            "message" => "Exercício não encontrado no banco de dados.",
+            "status" => 404,
+            "errors" => [],
+            "data" => []
+        ]);
+    }
+}


### PR DESCRIPTION
Este pull request adiciona a funcionalidade de deleção de exercícios.
Os usuários logados no sistema com o perfil de instrutor podem deletar os exercícios já cadastrados às suas contas. Em caso de tentativa de deleção de um exercício por outro usuário, o sistema irá retornar uma mensagem de erro informando que o usuário não tem permissão para executar essa operação.

Testes:
- Foram realizados testes unitários para garantir o funcionamento adequado do ExerciseController e do DeleteOneExerciseService.
- Os testes abrangem cenários de sucesso e falha, incluindo a tentativa de deletar um exercício que não se encontra no banco de dados, bem como a tentativa de deleção de exercício por usuários sem permissão para realizar essa ação.